### PR TITLE
set to use llvm 14.0.6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * text=auto
 
-*.patch binary
-*.diff binary
+*.patch text eol=lf
+*.diff text eol=lf
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - ""
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,6 +5,7 @@ macos_machine:
   - s390x-conda-linux-gnu        # [linux and s390x]
   - aarch64-conda-linux-gnu      # [linux and aarch64]
   - powerpc64le-conda-linux-gnu  # [linux and ppc64le]
+  - dummy  # [win]
 cross_platform:
   - osx-64         # [osx and x86_64]
   - osx-arm64      # [osx and arm64]
@@ -12,6 +13,7 @@ cross_platform:
   - linux-s390x    # [linux and s390x]
   - linux-aarch64  # [linux and aarch64]
   - linux-ppc64le  # [linux and ppc64le]
+  - dummpy         # [win]
 uname_machine:
   - x86_64       # [osx and x86_64]
   - arm64        # [osx and arm64]
@@ -19,6 +21,7 @@ uname_machine:
   - s390x        # [linux and s390x]
   - aarch64      # [linux and aarch64]
   - powerpc64le  # [linux and ppc64le]
+  - dummy        # [win]
 zip_keys:
   - - macos_machine
     - cross_platform

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-macos_machine:  # [osx]
+macos_machine:
   - x86_64-apple-darwin13.4.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
   - x86_64-conda-linux-gnu       # [linux and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,7 +4,7 @@ macos_machine:  # [osx]
   - x86_64-conda-linux-gnu       # [linux and x86_64]
   - s390x-conda-linux-gnu        # [linux and s390x]
   - aarch64-conda-linux-gnu      # [linux and aarch64]
-  - powerpc64le-conda-linux-gnu  # [linux adn ppc64le]
+  - powerpc64le-conda-linux-gnu  # [linux and ppc64le]
 cross_platform:
   - osx-64         # [osx and x86_64]
   - osx-arm64      # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,12 +1,24 @@
 macos_machine:  # [osx]
-  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
-  - arm64-apple-darwin20.0.0   # [osx and arm64]
+  - x86_64-apple-darwin13.4.0    # [osx and x86_64]
+  - arm64-apple-darwin20.0.0     # [osx and arm64]
+  - x86_64-conda-linux-gnu       # [linux and x86_64]
+  - s390x-conda-linux-gnu        # [linux and s390x]
+  - aarch64-conda-linux-gnu      # [linux and aarch64]
+  - powerpc64le-conda-linux-gnu  # [linux adn ppc64le]
 cross_platform:
-  - osx-64     # [x86_64]
-  - osx-arm64  # [arm64]
+  - osx-64         # [osx and x86_64]
+  - osx-arm64      # [osx and arm64]
+  - linux-64       # [linux and x86_64]
+  - linux-s390x    # [linux and s390x]
+  - linux-aarch64  # [linux and aarch64]
+  - linux-ppc64le  # [linux and ppc64le]
 uname_machine:
-  - x86_64     # [x86_64]
-  - arm64      # [arm64]
+  - x86_64       # [osx and x86_64]
+  - arm64        # [osx and arm64]
+  - x86_64       # [linux and x86_64]
+  - s390x        # [linux and s390x]
+  - aarch64      # [linux and aarch64]
+  - powerpc64le  # [linux and ppc64le]
 zip_keys:
   - - macos_machine
     - cross_platform

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 
 build:
   number: 25
-  skip: True  # [win or linux]
+  skip: True  # [win or (linux and s390x)]
   ignore_run_exports:
     - zlib
 
@@ -43,8 +43,8 @@ requirements:
     - zlib
     - llvmdev {{ llvm_version }}.*
     - libuuid   # [linux]
-    - tapi <1100   # [not arm64]
-    - tapi >=1100  # [arm64]
+    - tapi <1100   # [not (arm64 or linux)]
+    - tapi >=1100  # [arm64 or linux]
 
 outputs:
   - name: cctools_{{ cross_platform }}
@@ -64,8 +64,8 @@ outputs:
         - zlib
         - llvmdev {{ llvm_version }}.*
         - llvm {{ llvm_version }}.*
-        - tapi <1100   # [not arm64]
-        - tapi >=1100  # [arm64]
+        - tapi <1100   # [not (arm64 or linux)]
+        - tapi >=1100  # [arm64 or linux]
         - libcxx  # [osx]
         #- {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
       run:
@@ -112,8 +112,8 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-        - tapi <1100   # [not arm64]
-        - tapi >=1100  # [arm64]
+        - tapi <1100   # [not (arm64 or linux)]
+        - tapi >=1100  # [arm64 or linux]
         - libcxx  # [osx]
         - libuuid  # [linux]
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set cctools_version = '949.0.1' %}
 {% set ld64_version = '530' %}
-{% set llvm_version = "12.0.0" %}
+{% set llvm_version = "14.0.6" %}
 
 {% if cross_platform is not defined %}
 {% set cross_platform = "osx-64" %}
@@ -19,8 +19,8 @@ source:
       - patches/530-ld64-add-conda-specific-env-vars-to-modify-lib-search-paths.patch
 
 build:
-  number: 24
-  skip: True  # [win]
+  number: 25
+  skip: True  # [win or (linux and s390x)]
   ignore_run_exports:
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
       run:
         - libcxx  # [osx]
         - {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
-        - ldid
+        - ldid    # [osx]
       run_constrained:
         #- ld64 {{ ld64_version }}.*
         - cctools {{ cctools_version }}.*
@@ -119,7 +119,7 @@ outputs:
       run:
         - {{ pin_compatible("tapi") }}
         - libcxx  # [osx]
-        - ldid
+        - ldid    # [osx]
       run_constrained:
         - {{ pin_compatible("clang") }}
         - ld {{ ld64_version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,7 +129,7 @@ outputs:
       requires:
         - clang {{ llvm_version }}.*
       commands:
-        - test -f $PREFIX/bin/{{ macos_machine }}-ld
+        - test -f $PREFIX/bin/{{ macos_machine }}-ld  # [osx]
         - echo "int main() {}" > lto.c                                              # [osx]
         - clang -c lto.c -o lto.o -flto                                             # [osx]
         - $PREFIX/bin/{{ macos_machine }}-ld lto.o -o lto -lSystem -arch x86_64     # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -156,9 +156,9 @@ outputs:
       run_constrained:
         - cctools {{ cctools_version }}.*
         - cctools_{{ cross_platform }} {{ cctools_version }}.*
-    test:
-      commands:
-        - test -f $PREFIX/bin/ld
+    test:  # [osx]
+      commands:  # [osx]
+        - test -f $PREFIX/bin/ld  # [osx]
     about:
       home: https://github.com/tpoechtrager/cctools-port
       license: APSL-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 
 build:
   number: 25
-  skip: True  # [win or (linux and s390x)]
+  skip: True  # [win or linux]
   ignore_run_exports:
     - zlib
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ outputs:
         - test -f $PREFIX/libexec/as/arm/as        # [arm64]
         - test -f $PREFIX/bin/{{ macos_machine }}-as
         - test -f $PREFIX/bin/{{ macos_machine }}-ranlib
-        - test -f $PREFIX/bin/{{ macos_machine }}-ld
+        - test -f $PREFIX/bin/{{ macos_machine }}-ld    # [not linux]
         - test -f $PREFIX/bin/{{ macos_machine }}-ar
         - test -f $PREFIX/bin/{{ macos_machine }}-otool
         # Check that otool is functioning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
     patches:
       - patches/dont_link_with_libcxxabi.patch
       - patches/530-ld64-add-conda-specific-env-vars-to-modify-lib-search-paths.patch
+      - patches/ppc-int64_t.patch
 
 build:
   number: 25

--- a/recipe/patches/ppc-int64_t.patch
+++ b/recipe/patches/ppc-int64_t.patch
@@ -1,0 +1,16 @@
+Index: cctools-port-dbcdc0d36eeb47a7ac4b7d5abe772886fec52e56/cctools/include/foreign/ppc/types.h
+===================================================================
+--- cctools-port-dbcdc0d36eeb47a7ac4b7d5abe772886fec52e56.orig/cctools/include/foreign/ppc/types.h
++++ cctools-port-dbcdc0d36eeb47a7ac4b7d5abe772886fec52e56/cctools/include/foreign/ppc/types.h
+@@ -90,9 +90,9 @@ typedef	int			int32_t;
+ typedef	unsigned int		u_int32_t;
+ #ifndef _INT64_T
+ #define _INT64_T
+-typedef	long long		int64_t;
++typedef	long int64_t;
+ #endif
+-typedef	unsigned long long	u_int64_t;
++typedef	unsigned long u_int64_t;
+ 
+ #if __LP64__
+ typedef int64_t			register_t;


### PR DESCRIPTION
*  rebuild of cctools, and ld64 package for osx architectures using llvm 14.0.6
*  buiding cctools/ld64 for linux architectures, but s390x (had to build in front tapi 1100.0.11 for the linux archs)
*  Fixed building for power-pc due a type-mismatch in headers about LLP64 and LP64.
*  Made 'ldid' package used only by osx architectures
*  Expanded cbc.yaml file so that recipe can be rendered on all architectures