### PR TITLE
Rebuild for x86_64-apple-darwin20.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,7 @@
 build_parameters:
   - ""
 
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 macos_machine:
-  - x86_64-apple-darwin13.4.0    # [osx and x86_64]
+  - x86_64-apple-darwin20.0.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
   - x86_64-conda-linux-gnu       # [linux and x86_64]
   - s390x-conda-linux-gnu        # [linux and s390x]
@@ -36,10 +36,3 @@ c_compiler:
   - vs2017           # [win]
 vc:
   - 14
-c_compiler_version:     # [osx and x86_64]
-  - "10.0.0"                 # [osx and x86_64]
-cxx_compiler_version:   # [osx and x86_64]
-  - "10.0.0"                # [osx and x86_64]
-CONDA_BUILD_SYSROOT:  # [osx and x86_64]
-  - /opt/MacOSX10.14.sdk  # [osx and x86_64]
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
       - patches/ppc-int64_t.patch
 
 build:
-  number: 25
+  number: 26
   skip: True  # [win or (linux and s390x)]
   ignore_run_exports:
     - zlib
@@ -44,8 +44,7 @@ requirements:
     - zlib
     - llvmdev {{ llvm_version }}.*
     - libuuid   # [linux]
-    - tapi <1100   # [not (arm64 or linux)]
-    - tapi >=1100  # [arm64 or linux]
+    - tapi >=1100
 
 outputs:
   - name: cctools_{{ cross_platform }}
@@ -65,8 +64,7 @@ outputs:
         - zlib
         - llvmdev {{ llvm_version }}.*
         - llvm {{ llvm_version }}.*
-        - tapi <1100   # [not (arm64 or linux)]
-        - tapi >=1100  # [arm64 or linux]
+        - tapi >=1100
         - libcxx  # [osx]
         #- {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
       run:
@@ -113,8 +111,7 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-        - tapi <1100   # [not (arm64 or linux)]
-        - tapi >=1100  # [arm64 or linux]
+        - tapi >=1100
         - libcxx  # [osx]
         - libuuid  # [linux]
       run:
@@ -200,10 +197,12 @@ about:
   license_family: Other
   license_file: cctools/APPLE_LICENSE
   summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
+  description: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
+  doc_url: https://github.com/tpoechtrager/cctools-port
+  dev_url: https://github.com/tpoechtrager/cctools-port
 
 extra:
-  recipe-maintainers:
-    - isuruf
-    - mingwandroid
-    - davidbrochart
-    - katietz
+  skip-lints:
+    - host_section_needs_exact_pinnings
+    - should_use_compilers
+    - missing_tests


### PR DESCRIPTION
cctools 949.0.1
ld64 530

**Destination channel:** defaults

### Links

- [PKG-5178](https://anaconda.atlassian.net/browse/PKG-5178) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/4
  - https://github.com/AnacondaRecipes/tapi-feedstock/pull/3

### Explanation of changes:

- We need this for qt 6.7 in macos intel machines. The existing x86_64-apple-darwin13.4.0 is not capable of building with the minimal sdk version required for qt 6.7 due to using an old version of tapi.


[PKG-5178]: https://anaconda.atlassian.net/browse/PKG-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ