### PR TITLE
Revert "Merge pull request #3 from AnacondaRecipes/upgrade2" skip CI

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,3 @@
 build_parameters:
   - ""
 
-channels:
-  - rafaelmartins-qt
-
-upload_without_merge: true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 macos_machine:
-  - x86_64-apple-darwin20.0.0    # [osx and x86_64]
+  - x86_64-apple-darwin13.4.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
   - x86_64-conda-linux-gnu       # [linux and x86_64]
   - s390x-conda-linux-gnu        # [linux and s390x]
@@ -36,3 +36,10 @@ c_compiler:
   - vs2017           # [win]
 vc:
   - 14
+c_compiler_version:     # [osx and x86_64]
+  - "10.0.0"                 # [osx and x86_64]
+cxx_compiler_version:   # [osx and x86_64]
+  - "10.0.0"                # [osx and x86_64]
+CONDA_BUILD_SYSROOT:  # [osx and x86_64]
+  - /opt/MacOSX10.14.sdk  # [osx and x86_64]
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
       - patches/ppc-int64_t.patch
 
 build:
-  number: 26
+  number: 25
   skip: True  # [win or (linux and s390x)]
   ignore_run_exports:
     - zlib
@@ -44,7 +44,8 @@ requirements:
     - zlib
     - llvmdev {{ llvm_version }}.*
     - libuuid   # [linux]
-    - tapi >=1100
+    - tapi <1100   # [not (arm64 or linux)]
+    - tapi >=1100  # [arm64 or linux]
 
 outputs:
   - name: cctools_{{ cross_platform }}
@@ -64,7 +65,8 @@ outputs:
         - zlib
         - llvmdev {{ llvm_version }}.*
         - llvm {{ llvm_version }}.*
-        - tapi >=1100
+        - tapi <1100   # [not (arm64 or linux)]
+        - tapi >=1100  # [arm64 or linux]
         - libcxx  # [osx]
         #- {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
       run:
@@ -111,7 +113,8 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-        - tapi >=1100
+        - tapi <1100   # [not (arm64 or linux)]
+        - tapi >=1100  # [arm64 or linux]
         - libcxx  # [osx]
         - libuuid  # [linux]
       run:
@@ -197,12 +200,10 @@ about:
   license_family: Other
   license_file: cctools/APPLE_LICENSE
   summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
-  description: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
-  doc_url: https://github.com/tpoechtrager/cctools-port
-  dev_url: https://github.com/tpoechtrager/cctools-port
 
 extra:
-  skip-lints:
-    - host_section_needs_exact_pinnings
-    - should_use_compilers
-    - missing_tests
+  recipe-maintainers:
+    - isuruf
+    - mingwandroid
+    - davidbrochart
+    - katietz


### PR DESCRIPTION
This reverts commit ed774fa9c85d45473af774c0315b7f8365a15007, reversing changes made to 6728790ce0d6565d0bf73df9688fba30aa124562.

This version was pulled from defaults due to issues it introduced to do with compiling python packages with c extensions on osx-64 for py <=3.9.