### PR TITLE
Fix/overlinking and cross compile

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,7 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - "--suppress-variables"
-#  - "--error-overlinking"
+  - "--error-overlinking"
 
 upload_without_merge: True
 upload_to_staging_channel_in_pr: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -10,5 +10,3 @@ upload_channels:
 
 channels:
   - llvm-17.0.6-stage0
-
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,12 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+upload_without_merge: True
+
+upload_channels:
+  - llvm-17.0.6-stage0
+
+channels:
+  - llvm-17.0.6-stage0
+
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-upload_without_merge: True
-upload_to_staging_channel_in_pr: True
-channels: [ llvmdev17-boot ]
+aggregate_check:
+  - false

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,5 +3,4 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-aggregate_check:
-  - false
+aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,16 +1,9 @@
 macos_machine:
-  - x86_64-apple-darwin13.4.0
-  - arm64-apple-darwin20.0.0
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
 cross_platform:
-  - osx-64
-  - osx-arm64
-uname_machine:
-  - x86_64
-  - arm64
-zip_keys:
-  - - macos_machine
-    - cross_platform
-    - uname_machine
+  - osx-64     # [osx and x86_64]
+  - osx-arm64  # [osx and arm64]
 cxx_compiler:
   - clang_bootstrap  # [osx]
   - gxx              # [linux]

--- a/recipe/install-cctools-symlinks.sh
+++ b/recipe/install-cctools-symlinks.sh
@@ -1,7 +1,0 @@
-prefix="${macos_machine}-"
-
-pushd $PREFIX/bin
-  for tool in $(ls ${prefix}*); do
-    ln -s $PREFIX/bin/$tool $PREFIX/bin/${tool:${#prefix}} || true
-  done
-popd

--- a/recipe/install-cctools.sh
+++ b/recipe/install-cctools.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-set -e
-
-. activate "${BUILD_PREFIX}"
-cd "${SRC_DIR}"
+set -ex
 
 pushd cctools_build_final
   make install

--- a/recipe/install-cctools.sh
+++ b/recipe/install-cctools.sh
@@ -13,3 +13,11 @@ pushd "${PREFIX}"
   # This is packaged in ld64
   rm bin/*-ld
 popd
+
+prefix="${macos_machine}-"
+
+pushd $PREFIX/bin
+  for tool in $(ls ${prefix}*); do
+    ln -s $PREFIX/bin/$tool $PREFIX/bin/${tool:${#prefix}} || true
+  done
+popd

--- a/recipe/install-ld64-symlinks.sh
+++ b/recipe/install-ld64-symlinks.sh
@@ -1,1 +1,0 @@
-ln -s $PREFIX/bin/${macos_machine}-ld $PREFIX/bin/ld

--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-. activate "${BUILD_PREFIX}"
-cd "${SRC_DIR}"
+set -ex
 
 pushd cctools_build_final/ld64
   make install

--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -9,3 +9,5 @@ pushd cctools_build_final/ld64
     dsymutil ${PREFIX}/bin/*ld
   fi
 popd
+
+ln -s $PREFIX/bin/${macos_machine}-ld $PREFIX/bin/ld

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
       - patches/0004-Turn-off-outputIsMappableFile-when-building-to-osx-a.patch
 
 build:
-  number: 25
+  number: 0
   skip: True  # [win]
   ignore_run_exports:
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,9 +45,9 @@ requirements:
     #- xar
     # We only use the static library from this and only get away with that as it depends on nothing.
     - zlib
-    - llvmdev {{ llvm_version }}.*
-    - libuuid   # [linux]
-    - tapi
+    - llvmdev {{ llvm_version }}
+    - libuuid 1.41.5  # [linux]
+    - tapi 1100.0.11
   run:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
@@ -63,8 +63,7 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-        - libcxx  # [osx]
-        - tapi
+        - tapi 1100.0.11
       run:
         - tapi
       run_constrained:
@@ -100,7 +99,6 @@ outputs:
         - {{ pin_subpackage("ld64", exact=True) }}
       run:
         - {{ pin_subpackage("ld64", exact=True) }}
-        - libcxx  # [osx]
     test:
       commands:
         - test -f $PREFIX/bin/as

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,10 +2,6 @@
 {% set ld64_version = '711' %}
 {% set llvm_version = "14.0" %}
 
-{% if cross_platform is not defined %}
-{% set cross_platform = "osx-64" %}
-{% endif %}
-
 package:
   name: cctools-and-ld64
   version: {{ ld64_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,7 +161,7 @@ outputs:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
         - libc++.1.dylib
-    script: install-ld64-symlinks.sh
+    script: install-ld64.sh
     requirements:
       host:
         - llvm  {{ llvm_version }}.*
@@ -180,7 +180,7 @@ outputs:
 
   - name: cctools
     version: {{ cctools_version }}
-    script: install-cctools-symlinks.sh
+    script: install-cctools.sh
     build:
       skip: True   # [cross_platform != target_platform]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,8 @@ outputs:
     version: {{ cctools_version }}
     script: install-cctools.sh
     build:
+      # Don't cross compile
+      skip: True
       activate_in_script: True
       ignore_run_exports:
         - zlib
@@ -109,6 +111,8 @@ outputs:
     version: {{ ld64_version }}
     script: install-ld64.sh
     build:
+      # Don't cross compile
+      skip: True
       activate_in_script: True
       missing_dso_whitelist:
         - /usr/lib/libxar.1.dylib  # [osx]
@@ -133,7 +137,6 @@ outputs:
         - {{ pin_compatible("clang") }}
         - ld {{ ld64_version }}.*
         - cctools {{ cctools_version }}.*
-        - cctools_{{ cross_platform }} {{ cctools_version }}.*
     test:
       requires:
         - clang {{ llvm_version }}.*
@@ -163,12 +166,8 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-        - {{ pin_subpackage("ld64_" + cross_platform, exact=True) }}
-      run:
-        - {{ pin_subpackage("ld64_" + cross_platform, exact=True) }}
       run_constrained:
         - cctools {{ cctools_version }}.*
-        - cctools_{{ cross_platform }} {{ cctools_version }}.*
     test:
       commands:
         - test -f $PREFIX/bin/ld
@@ -189,10 +188,8 @@ outputs:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
         - {{ pin_subpackage("ld64", exact=True) }}
-        - {{ pin_subpackage("cctools_" + cross_platform, exact=True) }}
       run:
         - {{ pin_subpackage("ld64", exact=True) }}
-        - {{ pin_subpackage("cctools_" + cross_platform, exact=True) }}
     test:
       commands:
         - test -f $PREFIX/bin/as

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -168,7 +168,6 @@ outputs:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
-      run:
         - libcxx  # [osx]
       run_constrained:
         - cctools {{ cctools_version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ build:
     - zlib
   missing_dso_whitelist:
     - libc++.1.dylib  # [osx]
-
+    - "*/libtapi.dylib"  # [osx]
 requirements:
   build:
     - clangxx {{ llvm_version }}.*  # [linux]
@@ -64,6 +64,7 @@ outputs:
         - zlib
       missing_dso_whitelist:
         - libc++.1.dylib  # [osx]
+        - "*/libtapi.dylib"  # [osx]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -160,12 +161,15 @@ outputs:
     build:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
-        - libc++.1.dylib
+        - libc++.1.dylib  # [osx]
+        - "*/libtapi.dylib"  # [osx]
     script: install-ld64.sh
     requirements:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
+      run:
+        - libcxx  # [osx]
       run_constrained:
         - cctools {{ cctools_version }}.*
     test:
@@ -190,6 +194,7 @@ outputs:
         - {{ pin_subpackage("ld64", exact=True) }}
       run:
         - {{ pin_subpackage("ld64", exact=True) }}
+        - libcxx  # [osx]
     test:
       commands:
         - test -f $PREFIX/bin/as

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ outputs:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
         - "*/libc++.1.dylib"  # [osx]
+        - "*/libtapi.dylib"  # [osx]
     script: install-ld64.sh
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ build:
   ignore_run_exports:
     - zlib
   missing_dso_whitelist:
-    - libc++.1.dylib  # [osx]
+    - "*/libc++.1.dylib"  # [osx]
     - "*/libtapi.dylib"  # [osx]
 requirements:
   build:
@@ -63,7 +63,7 @@ outputs:
       ignore_run_exports:
         - zlib
       missing_dso_whitelist:
-        - libc++.1.dylib  # [osx]
+        - "*/libc++.1.dylib"  # [osx]
         - "*/libtapi.dylib"  # [osx]
     requirements:
       build:
@@ -117,7 +117,7 @@ outputs:
       activate_in_script: True
       missing_dso_whitelist:
         - /usr/lib/libxar.1.dylib  # [osx]
-        - libc++.1.dylib  # [osx]
+        - "*/libc++.1.dylib"  # [osx]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -161,7 +161,7 @@ outputs:
     build:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
-        - libc++.1.dylib  # [osx]
+        - "*/libc++.1.dylib"  # [osx]
         - "*/libtapi.dylib"  # [osx]
     script: install-ld64.sh
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ build:
     - zlib
   missing_dso_whitelist:
     - "*/libc++.1.dylib"  # [osx]
-    - "*/libtapi.dylib"  # [osx]
 requirements:
   build:
     - clangxx {{ llvm_version }}.*  # [linux]
@@ -162,13 +161,15 @@ outputs:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
         - "*/libc++.1.dylib"  # [osx]
-        - "*/libtapi.dylib"  # [osx]
     script: install-ld64.sh
     requirements:
       host:
         - llvm  {{ llvm_version }}.*
         - clang {{ llvm_version }}.*
         - libcxx  # [osx]
+        - tapi
+      run:
+        - tapi
       run_constrained:
         - cctools {{ cctools_version }}.*
     test:
@@ -188,7 +189,6 @@ outputs:
       skip: True   # [cross_platform != target_platform]
       missing_dso_whitelist:
         - "*/libc++.1.dylib"  # [osx]
-        - "*/libtapi.dylib"  # [osx]
     requirements:
       host:
         - llvm  {{ llvm_version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,109 +52,6 @@ requirements:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]
 
 outputs:
-  - name: cctools_{{ cross_platform }}
-    version: {{ cctools_version }}
-    script: install-cctools.sh
-    build:
-      # Don't cross compile
-      skip: True
-      activate_in_script: True
-      ignore_run_exports:
-        - zlib
-      missing_dso_whitelist:
-        - "*/libc++.1.dylib"  # [osx]
-        - "*/libtapi.dylib"  # [osx]
-    requirements:
-      build:
-        - {{ compiler('cxx') }}
-        - autoconf
-        - automake
-        - make
-      host:
-        - zlib
-        - llvmdev {{ llvm_version }}.*
-        - llvm {{ llvm_version }}.*
-        - tapi
-        - libcxx  # [osx]
-        - {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
-      run:
-        - libcxx  # [osx]
-        - {{ pin_subpackage("ld64_" + cross_platform, max_pin="x.x") }}
-        - ldid    # [osx]
-      run_constrained:
-        - ld64 {{ ld64_version }}.*
-        - cctools {{ cctools_version }}.*
-        # clang might pull in the wrong cctools otherwise
-        - clang {{ llvm_version }}.*
-    test:
-      commands:
-        # For arm64, cctools as calls the clang integrated assembler. Don't check for it
-        - test -f $PREFIX/libexec/as/x86_64/as
-        - test -f $PREFIX/libexec/as/arm/as        # [arm64]
-        - test -f $PREFIX/bin/{{ macos_machine }}-as
-        - test -f $PREFIX/bin/{{ macos_machine }}-ranlib
-        - test -f $PREFIX/bin/{{ macos_machine }}-ld
-        - test -f $PREFIX/bin/{{ macos_machine }}-ar
-        - test -f $PREFIX/bin/{{ macos_machine }}-otool
-        # Check that otool is functioning
-        - $PREFIX/bin/{{ macos_machine }}-otool -l $PREFIX/bin/{{ macos_machine }}-otool  # [target_platform == build_platform and target_platform == cross_platform]
-        - test -f $PREFIX/bin/{{ macos_machine }}-install_name_tool
-        - test -f $PREFIX/bin/{{ macos_machine }}-strip
-    about:
-      home: https://github.com/tpoechtrager/cctools-port
-      license: APSL-2.0
-      license_family: Other
-      license_file: cctools/APPLE_LICENSE
-      summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
-
-  - name: ld64_{{ cross_platform }}
-    version: {{ ld64_version }}
-    script: install-ld64.sh
-    build:
-      # Don't cross compile
-      skip: True
-      activate_in_script: True
-      missing_dso_whitelist:
-        - /usr/lib/libxar.1.dylib  # [osx]
-        - "*/libc++.1.dylib"  # [osx]
-    requirements:
-      build:
-        - {{ compiler('cxx') }}
-        - autoconf
-        - automake
-        - make
-      host:
-        - llvm  {{ llvm_version }}.*
-        - clang {{ llvm_version }}.*
-        - tapi
-        - libcxx  # [osx]
-        - libuuid  # [linux]
-      run:
-        - {{ pin_compatible("tapi") }}
-        - libcxx  # [osx]
-        - ldid    # [osx]
-      run_constrained:
-        - {{ pin_compatible("clang") }}
-        - ld {{ ld64_version }}.*
-        - cctools {{ cctools_version }}.*
-    test:
-      requires:
-        - clang {{ llvm_version }}.*
-      commands:
-        - test -f $PREFIX/bin/{{ macos_machine }}-ld
-        - echo "int main() {}" > lto.c                                              # [osx]
-        - clang -c lto.c -o lto.o -flto                                             # [osx]
-        - $PREFIX/bin/{{ macos_machine }}-ld lto.o -o lto -lSystem -arch x86_64     # [osx and x86_64]
-        - $PREFIX/bin/{{ macos_machine }}-ld lto.o -o lto -lSystem -arch arm64      # [osx and arm64]
-      downstreams:
-        - gfortran_osx-64  # [osx and cross_platform=="osx-64"]
-    about:
-      home: https://github.com/tpoechtrager/cctools-port
-      license: APSL-2.0
-      license_family: Other
-      license_file: cctools/ld64/APPLE_LICENSE
-      summary: Darwin Mach-O cross linker
-
   - name: ld64
     version: {{ ld64_version }}
     build:
@@ -181,6 +78,13 @@ outputs:
       license_family: Other
       license_file: cctools/ld64/APPLE_LICENSE
       summary: Darwin Mach-O native linker
+      description: |
+        ld64 is Apple's linker for creating Mach-O executables and libraries.
+        This native version provides:
+        - Creation of Mach-O executables and dynamic libraries
+        - Support for macOS-specific linking features
+        - Generation of debug information compatible with macOS tools
+        - Dynamic library versioning support
 
   - name: cctools
     version: {{ cctools_version }}
@@ -211,6 +115,14 @@ outputs:
       license_family: Other
       license_file: cctools/APPLE_LICENSE
       summary: Native assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files
+      description: |
+        This package provides native tools for working with macOS/Darwin binaries:
+        - as: Assembler for macOS
+        - ranlib: Archive index generator
+        - ar: Archive manager for creating static libraries
+        - otool: Object file examination tool similar to objdump
+        - install_name_tool: Tool to modify dynamic shared library dependencies
+        - strip: Tool to remove symbols from binaries
 
 about:
   home: https://github.com/tpoechtrager/cctools-port
@@ -220,6 +132,20 @@ about:
   license_family: Other
   license_file: cctools/APPLE_LICENSE
   summary: Assembler, archiver, ranlib, libtool, otool et al for Darwin Mach-O files. Darwin Mach-O linker.
+  description: |
+    This package contains Apple's native toolchain components ported to other platforms:
+
+    cctools - A collection of macOS/Darwin binary utilities including:
+    - as: Assembler for converting assembly language to machine code
+    - ar/ranlib: Archive management tools for static libraries
+    - otool: Object file displaying tool (similar to objdump)
+    - install_name_tool: Utility to manipulate dynamic shared library install names
+    - strip: Tool to remove symbols and sections from binaries
+
+    ld64 - The Darwin/macOS linker that creates:
+    - Mach-O executables and libraries
+    - Universal (fat) binaries for multiple architectures
+    - Dynamic libraries with proper versioning
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -187,6 +187,9 @@ outputs:
     script: install-cctools.sh
     build:
       skip: True   # [cross_platform != target_platform]
+      missing_dso_whitelist:
+        - "*/libc++.1.dylib"  # [osx]
+        - "*/libtapi.dylib"  # [osx]
     requirements:
       host:
         - llvm  {{ llvm_version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ build:
   skip: True  # [win]
   ignore_run_exports:
     - zlib
+  missing_dso_whitelist:
+    - libc++.1.dylib  # [osx]
 
 requirements:
   build:
@@ -58,6 +60,8 @@ outputs:
       activate_in_script: True
       ignore_run_exports:
         - zlib
+      missing_dso_whitelist:
+        - libc++.1.dylib  # [osx]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -108,6 +112,7 @@ outputs:
       activate_in_script: True
       missing_dso_whitelist:
         - /usr/lib/libxar.1.dylib  # [osx]
+        - libc++.1.dylib  # [osx]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -151,6 +156,8 @@ outputs:
     version: {{ ld64_version }}
     build:
       skip: True   # [cross_platform != target_platform]
+      missing_dso_whitelist:
+        - libc++.1.dylib
     script: install-ld64-symlinks.sh
     requirements:
       host:


### PR DESCRIPTION
## Notes

- Remove cross-compiling:
   - Previously, linux-* builds were running and build osx packages. Similarly, osx-arm was building osx-64 packages and vice-versa. Linux builds are now skipped properly. And osx packages build natively. 
- Fix overlinking errors.  