### PR TITLE
Rebuild/1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-staging_channel_upload_target: llvm-17.0.6-verify-2
-channels:
-  - https://staging.continuum.io/prefect/lllvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-17.0.6-stage2-attempt-4"
+
+staging_channel_upload_target: llvm-17.0.6-verify-2
+channels:
+  - llvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,4 @@ build_parameters:
 
 staging_channel_upload_target: llvm-17.0.6-verify-2
 channels:
-  - llvm-17.0.6-verify-2
+  - https://staging.continuum.io/prefect/lllvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,3 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
 staging_channel_upload_target: llvm-17.0.6-verify-2
 channels:
   - https://staging.continuum.io/prefect/lllvm-17.0.6-verify-2

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,20 +1,11 @@
 macos_machine:
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
-cross_platform:
-  - osx-64     # [osx and x86_64]
-  - osx-arm64  # [osx and arm64]
-cxx_compiler:
-  - clang_bootstrap  # [osx]
-  - gxx              # [linux]
-  - vs2017           # [win]
-c_compiler:
-  - clang_bootstrap  # [osx]
-  - gcc              # [linux]
-  - vs2017           # [win]
+
 vc:
   - 14
+
 c_compiler_version:     # [osx]
-  - "*"                 # [osx]
+  - 17                  # [osx]
 cxx_compiler_version:   # [osx]
-  - "*"                 # [osx]
+  - 17                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - patches/0004-Turn-off-outputIsMappableFile-when-building-to-osx-a.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [not osx]
 requirements:
   build:


### PR DESCRIPTION
cctools-and-ld64

**Destination channel:** defaults

### Explanation of changes:

- Build with clang 17 instead of clang_bootstrap
    - Eliminates need for a hack in clang-compiler-activation. 
