### PR TITLE
cctools v1021.4, ld64 v954.16

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,4 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: llvm-20.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
+  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-staging_channel_upload_target: llvm-20.1.8-stage1-build-0
+staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,7 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
 staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-19.1.7-stage2-build-2"
+staging_channel_upload_target: llvm-20.1.8-stage1-build-0
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,7 @@ pushd cctools
   sed -i.bak "s/libLTO.dylib/${LLVM_LTO_LIBRARY}/g" ld64/src/ld/InputFiles.cpp
   sed -i.bak "s@llvm/libLTO.so@${LLVM_LTO_LIBRARY}@g" ld64/src/ld/InputFiles.cpp
   sed -i.bak "s/libLTO.so/${LLVM_LTO_LIBRARY}/g" ld64/src/ld/InputFiles.cpp
-  sed -i.bak "s/libLTO.dylib/${LLVM_LTO_LIBRARY}/g" ld64/doc/man/man1/ld.1
+  sed -i.bak "s/libLTO.dylib/${LLVM_LTO_LIBRARY}/g" ld64/doc/man/man1/ld-classic.1
   sed -i.bak "s/libLTO.dylib/${LLVM_LTO_LIBRARY}/g" libstuff/llvm.c
   sed -i.bak "s/libLTO.so/${LLVM_LTO_LIBRARY}/g" libstuff/llvm.c
   sed -i.bak "s/libLTO.dylib/${LLVM_LTO_LIBRARY}/g" ld64/src/ld/parsers/lto_file.cpp

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 c_compiler_version:     # [osx]
-  - 19                  # [osx]
+  - 20                  # [osx]
 cxx_compiler_version:   # [osx]
-  - 19                  # [osx]
+  - 20                  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set cctools_version = '1010.6' %}
-{% set ld64_version = '951.9' %}
+{% set cctools_version = '1021.4' %}
+{% set ld64_version = '954.16' %}
 
 package:
   name: cctools-and-ld64
@@ -7,15 +7,16 @@ package:
 
 source:
   # latest commit from branch {{ cctools_version }}-ld64-{{ ld64_version }}
-  - url: https://github.com/tpoechtrager/cctools-port/archive/d8d666a78745f487f071fd5fa30dc5f7452b4ee6.tar.gz
-    sha256: b8c59ed076e1028eedd9401086b23454befabfe8ec97766acd4c4a4c7e280dba
+  - url: https://github.com/tpoechtrager/cctools-port/archive/7ce3e9d500f9fa310f97507e84be763b2e8389ce.tar.gz
+    sha256: fd9b04a97d2360991a414b0aac1306ee627712e48423dc7d724411592be55403
     patches:
       - patches/0001-Don-t-link-with-libc-abi.patch
       - patches/0002-ld64-add-conda-specific-env-vars-to-modify-lib-searc.patch
+      - patches/0003-point-target-otool-to-llvm-otool-in-same-folder.patch
 
 
 build:
-  number: 2
+  number: 0
   skip: True  # [not osx]
 requirements:
   build:

--- a/recipe/patches/0001-Don-t-link-with-libc-abi.patch
+++ b/recipe/patches/0001-Don-t-link-with-libc-abi.patch
@@ -1,4 +1,4 @@
-From ddc13789b988a5790a3e51330b2d182c0cf1aa2b Mon Sep 17 00:00:00 2001
+From 2987c632878629c238935046b48d0f101d8875db Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 26 Nov 2019 03:13:34 -0600
 Subject: [PATCH 1/4] Don't link with libc++abi
@@ -8,7 +8,7 @@ Subject: [PATCH 1/4] Don't link with libc++abi
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/cctools/configure.ac b/cctools/configure.ac
-index f14dafe..3f857bb 100644
+index 57204a0..94f806f 100644
 --- a/cctools/configure.ac
 +++ b/cctools/configure.ac
 @@ -255,12 +255,10 @@ AC_CHECK_FUNC([write64],[AC_DEFINE(HAVE_WRITE64, 1)])

--- a/recipe/patches/0002-ld64-add-conda-specific-env-vars-to-modify-lib-searc.patch
+++ b/recipe/patches/0002-ld64-add-conda-specific-env-vars-to-modify-lib-searc.patch
@@ -1,4 +1,4 @@
-From fcc4915e0e69964cfa338cd500eb53c4464a9ade Mon Sep 17 00:00:00 2001
+From 6099989b3001e5ad2e067d6bc4f3ebed2c8fa09e Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Sep 2019 05:17:30 +0000
 Subject: [PATCH 2/4] ld64: add conda specific env vars to modify lib search
@@ -9,10 +9,10 @@ Subject: [PATCH 2/4] ld64: add conda specific env vars to modify lib search
  1 file changed, 30 insertions(+), 5 deletions(-)
 
 diff --git a/cctools/ld64/src/ld/Options.cpp b/cctools/ld64/src/ld/Options.cpp
-index aafff2d..53dc3b3 100644
+index d2c0388..2ff6322 100644
 --- a/cctools/ld64/src/ld/Options.cpp
 +++ b/cctools/ld64/src/ld/Options.cpp
-@@ -4398,12 +4398,28 @@ bool Options::shouldUseBuildVersion(ld::Platform plat, uint32_t minOSvers) const
+@@ -4427,12 +4427,28 @@ bool Options::shouldUseBuildVersion(ld::Platform plat, uint32_t minOSvers) const
  
  void Options::buildSearchPaths(int argc, const char* argv[])
  {
@@ -42,7 +42,7 @@ index aafff2d..53dc3b3 100644
  	// scan through argv looking for -L, -F, -Z, and -syslibroot options
  	for(int i=0; i < argc; ++i) {
  		if ( (argv[i][0] == '-') && (argv[i][1] == 'L') ) {
-@@ -4435,7 +4451,7 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+@@ -4464,7 +4480,7 @@ void Options::buildSearchPaths(int argc, const char* argv[])
  			frameworkPaths.push_back(frameworkSearchDir);
  		}
  		else if ( strcmp(argv[i], "-Z") == 0 )
@@ -51,7 +51,7 @@ index aafff2d..53dc3b3 100644
  		else if ( strcmp(argv[i], "-v") == 0 ) {
  			fVerbose = true;
  			extern const char ld_classicVersionString[];
-@@ -4559,6 +4575,10 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+@@ -4588,6 +4604,10 @@ void Options::buildSearchPaths(int argc, const char* argv[])
  			fForceLoadSwiftLibs = true;
  		}
  	}
@@ -62,7 +62,7 @@ index aafff2d..53dc3b3 100644
  	int standardLibraryPathsStartIndex = libraryPaths.size();
  	int standardFrameworkPathsStartIndex = frameworkPaths.size();
  	if ( addStandardLibraryDirectories ) {
-@@ -4568,8 +4588,12 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+@@ -4597,8 +4617,12 @@ void Options::buildSearchPaths(int argc, const char* argv[])
  			frameworkPaths.push_back("/System/DriverKit/System/Library/Frameworks/");
  		}
  		else {
@@ -76,7 +76,7 @@ index aafff2d..53dc3b3 100644
  
  			frameworkPaths.push_back("/Library/Frameworks/");
  			frameworkPaths.push_back("/System/Library/Frameworks/");
-@@ -4585,7 +4609,8 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+@@ -4614,7 +4638,8 @@ void Options::buildSearchPaths(int argc, const char* argv[])
  	}
  
  	// now merge sdk and library paths to make real search paths
@@ -86,7 +86,7 @@ index aafff2d..53dc3b3 100644
  	int libIndex = 0;
  	for (std::vector<const char*>::iterator it = libraryPaths.begin(); it != libraryPaths.end(); ++it, ++libIndex) {
  		const char* libDir = *it;
-@@ -4630,7 +4655,7 @@ void Options::buildSearchPaths(int argc, const char* argv[])
+@@ -4659,7 +4684,7 @@ void Options::buildSearchPaths(int argc, const char* argv[])
  					else
  						fLibrarySearchPaths.push_back(libDir);
  				}

--- a/recipe/patches/0003-point-target-otool-to-llvm-otool-in-same-folder.patch
+++ b/recipe/patches/0003-point-target-otool-to-llvm-otool-in-same-folder.patch
@@ -1,0 +1,54 @@
+From e19ac44874d56d069d405730bdd6f30fb7674ffe Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Tue, 19 Nov 2024 20:54:51 +1100
+Subject: [PATCH 4/4] point `<target>-otool` to `llvm-otool` in same folder
+
+---
+ cctools/otool-wrapper/main.c | 30 +++++++++++++++++++++++++++---
+ 1 file changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/cctools/otool-wrapper/main.c b/cctools/otool-wrapper/main.c
+index 892d0fb..c004ae2 100644
+--- a/cctools/otool-wrapper/main.c
++++ b/cctools/otool-wrapper/main.c
+@@ -2,13 +2,37 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ 
++#include <string>
++
+ int main(int argc, char *argv[]) {
+-    // Assuming llvm-otool binary is in the PATH, otherwise provide the full path
+-    char *binaryPath = "llvm-otool";
++    // we need to replace
++    //   <absolute_path>/x86_64-apple-darwin13.4.0-otool
++    //   <absolute_path>/arm64-apple-darwin20.0.0-otool
++    // coming from argv[0] with
++    //   <absolute_path>/llvm-otool
++    // for this, just detect the last slash and replace everything after that
++    int path_length = (int)strlen(argv[0]);
++
++    otool_orig = (char*)malloc(path_length + 1);
++    memcpy(otool_orig, argv[0], path_length);
++
++    for (i = (int)path_length - 1; i >= 0; --i) {
++      if (otool_orig[i] == '/') {
++        // set to null byte so the string ends before the basename
++        otool_orig[i] = '\0';
++        break;
++      }
++    }
++
++    std::string otool_modified = {otool_orig};
++    otool_modified += "/llvm-otool";
++    // std::string constructor for otool_modified did a deep-copy
++    free(otool_orig);
+ 
+     // Prepare the arguments array for execvp
+     char *new_argv[argc + 1]; // +1 for the NULL terminator
+-    new_argv[0] = binaryPath;
++    // don't want null-terminator between arguments; --> use .data(), not .c_str()
++    new_argv[0] = otool_modified.data();
+     for (int i = 1; i < argc; ++i) {
+         new_argv[i] = argv[i];
+     }


### PR DESCRIPTION
cctools v1021.4 and ld64 v954.16

## Links
- [PKG-9270](https://anaconda.atlassian.net/browse/PKG-9270)
- [Artifacts](https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0)

## Changes
- Rebase patches
- Build with llvm 20


## Related PRs
- ✅ https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/17
- ✅  https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/23
- https://github.com/AnacondaRecipes/libcxx-feedstock/pull/15
- https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/29
- https://github.com/AnacondaRecipes/clangdev-feedstock/pull/16
- https://github.com/AnacondaRecipes/compiler-rt-feedstock/pull/9
-  ✅ https://github.com/AnacondaRecipes/mlir-feedstock/pull/8
-  ✅ https://github.com/AnacondaRecipes/lld-feedstock/pull/12
- https://github.com/AnacondaRecipes/openmp-feedstock/pull/6
- https://github.com/AnacondaRecipes/clang-win-activation-feedstock/pull/6
- https://github.com/AnacondaRecipes/flang-feedstock/pull/2
- https://github.com/AnacondaRecipes/flang-activation-feedstock/pull/1


[PKG-9270]: https://anaconda.atlassian.net/browse/PKG-9270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ