### PR TITLE
cctools-and-ld64: Fix ld64 softlink dyld rpath issue

### DIFF
--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -9,22 +9,24 @@ pushd cctools_build_final/ld64
   fi
 popd
 
-# Ensure the ld binary has an absolute LC_RPATH to find libtapi.dylib
-# regardless of how the binary is invoked. The default @loader_path/../lib/
-# rpath fails when conda-build extracts the package to a temp pkgs cache
-# on a different filesystem and uses softlinks: macOS dyld resolves
-# @loader_path to the softlink target (the cache directory), where lib/
-# does not exist.
+# Rewrite LC_LOAD_DYLIB for libtapi from @rpath/libtapi.dylib to an
+# absolute ${PREFIX}/lib/libtapi.dylib path.
 #
-# conda's LDFLAGS normally includes -Wl,-rpath,$PREFIX/lib which adds this
-# rpath at link time. If for some reason it's missing, add it via
-# install_name_tool (and re-sign the binary). conda-build's prefix
-# replacement rewrites the absolute path to the user's install prefix at
-# install time.
-if ! otool -l "${PREFIX}/bin/${macos_machine}-ld" | grep -q " path ${PREFIX}/lib "; then
-  install_name_tool -add_rpath "${PREFIX}/lib" "${PREFIX}/bin/${macos_machine}-ld"
-  codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
-  codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"
-fi
+# Why: the default @rpath/libtapi.dylib fails when conda-build extracts
+# the package into a temp pkgs cache on a different filesystem and uses
+# softlinks: macOS dyld follows the symlink when resolving @rpath via
+# @loader_path/../lib (the only LC_RPATH entry), landing in the cache
+# directory where lib/ does not exist. @executable_path has the same
+# issue (verified — it also follows symlinks).
+#
+# LC_LOAD_DYLIB with an absolute path does NOT go through rpath
+# resolution, so it's not affected by the symlink-follow behavior.
+# conda-build detects the prefix string in the binary and rewrites it
+# to the user's install prefix at install time via its binary prefix
+# replacement mechanism.
+install_name_tool -change @rpath/libtapi.dylib "${PREFIX}/lib/libtapi.dylib" "${PREFIX}/bin/${macos_machine}-ld"
+# install_name_tool invalidates the code signature; re-sign ad-hoc.
+codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
+codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"
 
 ln -s $PREFIX/bin/${macos_machine}-ld $PREFIX/bin/ld

--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -9,16 +9,22 @@ pushd cctools_build_final/ld64
   fi
 popd
 
-# Add an absolute LC_RPATH so libtapi.dylib is found regardless of how the
-# binary is invoked. The default @loader_path/../lib/ rpath fails when
-# conda-build extracts the package to a temp pkgs cache on a different
-# filesystem and uses softlinks: macOS dyld resolves @loader_path to the
-# softlink target (the cache directory), where lib/ does not exist.
-# conda-build's prefix replacement rewrites this absolute path to the
-# user's install prefix at install time.
-install_name_tool -add_rpath "${PREFIX}/lib" "${PREFIX}/bin/${macos_machine}-ld"
-# install_name_tool invalidates the code signature; re-sign ad-hoc.
-codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
-codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"
+# Ensure the ld binary has an absolute LC_RPATH to find libtapi.dylib
+# regardless of how the binary is invoked. The default @loader_path/../lib/
+# rpath fails when conda-build extracts the package to a temp pkgs cache
+# on a different filesystem and uses softlinks: macOS dyld resolves
+# @loader_path to the softlink target (the cache directory), where lib/
+# does not exist.
+#
+# conda's LDFLAGS normally includes -Wl,-rpath,$PREFIX/lib which adds this
+# rpath at link time. If for some reason it's missing, add it via
+# install_name_tool (and re-sign the binary). conda-build's prefix
+# replacement rewrites the absolute path to the user's install prefix at
+# install time.
+if ! otool -l "${PREFIX}/bin/${macos_machine}-ld" | grep -q " path ${PREFIX}/lib "; then
+  install_name_tool -add_rpath "${PREFIX}/lib" "${PREFIX}/bin/${macos_machine}-ld"
+  codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
+  codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"
+fi
 
 ln -s $PREFIX/bin/${macos_machine}-ld $PREFIX/bin/ld

--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -9,4 +9,16 @@ pushd cctools_build_final/ld64
   fi
 popd
 
+# Add an absolute LC_RPATH so libtapi.dylib is found regardless of how the
+# binary is invoked. The default @loader_path/../lib/ rpath fails when
+# conda-build extracts the package to a temp pkgs cache on a different
+# filesystem and uses softlinks: macOS dyld resolves @loader_path to the
+# softlink target (the cache directory), where lib/ does not exist.
+# conda-build's prefix replacement rewrites this absolute path to the
+# user's install prefix at install time.
+install_name_tool -add_rpath "${PREFIX}/lib" "${PREFIX}/bin/${macos_machine}-ld"
+# install_name_tool invalidates the code signature; re-sign ad-hoc.
+codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
+codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"
+
 ln -s $PREFIX/bin/${macos_machine}-ld $PREFIX/bin/ld

--- a/recipe/install-ld64.sh
+++ b/recipe/install-ld64.sh
@@ -9,22 +9,29 @@ pushd cctools_build_final/ld64
   fi
 popd
 
-# Rewrite LC_LOAD_DYLIB for libtapi from @rpath/libtapi.dylib to an
-# absolute ${PREFIX}/lib/libtapi.dylib path.
+# Bundle libtapi.dylib INSIDE the ld64 package at a location adjacent to
+# the ld binary, and rewrite LC_LOAD_DYLIB to load it via @loader_path.
 #
-# Why: the default @rpath/libtapi.dylib fails when conda-build extracts
-# the package into a temp pkgs cache on a different filesystem and uses
-# softlinks: macOS dyld follows the symlink when resolving @rpath via
-# @loader_path/../lib (the only LC_RPATH entry), landing in the cache
-# directory where lib/ does not exist. @executable_path has the same
-# issue (verified — it also follows symlinks).
+# Why: conda-build's binary relocation rewrites BOTH absolute LC_RPATH
+# AND absolute LC_LOAD_DYLIB paths back to @rpath/@loader_path form for
+# portability. So we cannot use absolute paths to libtapi — they get
+# rewritten away during packaging.
 #
-# LC_LOAD_DYLIB with an absolute path does NOT go through rpath
-# resolution, so it's not affected by the symlink-follow behavior.
-# conda-build detects the prefix string in the binary and rewrites it
-# to the user's install prefix at install time via its binary prefix
-# replacement mechanism.
-install_name_tool -change @rpath/libtapi.dylib "${PREFIX}/lib/libtapi.dylib" "${PREFIX}/bin/${macos_machine}-ld"
+# The fundamental problem is that libtapi is in a SEPARATE conda package
+# (tapi). When conda-build extracts ld64 and tapi into separate temp
+# cache directories and uses softlinks (cross-filesystem fallback),
+# macOS dyld follows the symlink to the ld64 cache dir, where libtapi
+# is not adjacent. @loader_path, @executable_path, and @rpath all
+# follow the symlink to the cache target.
+#
+# Fix: copy libtapi.dylib into ld64's own bin/_lib/ directory. Now both
+# the binary and libtapi are in the same package (same cache extraction
+# directory), so @loader_path/_lib/libtapi.dylib resolves correctly
+# even after symlink-following. The path is relative (no prefix),
+# so conda-build leaves it alone.
+mkdir -p "${PREFIX}/bin/_lib"
+cp "${PREFIX}/lib/libtapi.dylib" "${PREFIX}/bin/_lib/libtapi.dylib"
+install_name_tool -change @rpath/libtapi.dylib @loader_path/_lib/libtapi.dylib "${PREFIX}/bin/${macos_machine}-ld"
 # install_name_tool invalidates the code signature; re-sign ad-hoc.
 codesign --remove-signature "${PREFIX}/bin/${macos_machine}-ld" 2>/dev/null || true
 codesign --sign - "${PREFIX}/bin/${macos_machine}-ld"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1  # Stage 2: c_compiler_version=22 + libtapi absolute LC_LOAD_DYLIB fix
+  number: 1  # Stage 2: c_compiler_version=22 + bundled libtapi for softlink fix
   skip: True  # [not osx]
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1  # Stage 2: c_compiler_version=22 for clang 22.* constraint + ld64 rpath fix
+  number: 1  # Stage 2: c_compiler_version=22 for clang 22.* + ld64 rpath fix (idempotent)
   skip: True  # [not osx]
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1  # Stage 2: c_compiler_version=22 for clang 22.* + ld64 rpath fix (idempotent)
+  number: 1  # Stage 2: c_compiler_version=22 + libtapi absolute LC_LOAD_DYLIB fix
   skip: True  # [not osx]
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 1  # Stage 2: rebuilt with c_compiler_version=22 for clang 22.* constraint
+  number: 1  # Stage 2: c_compiler_version=22 for clang 22.* constraint + ld64 rpath fix
   skip: True  # [not osx]
 requirements:
   build:


### PR DESCRIPTION
cctools-and-ld64 1030.6.3 / 956.6 (ld64 libtapi softlink fix)

**Destination channel:** defaults

### Links

- [PKG-13333](https://anaconda.atlassian.net/browse/PKG-13333)
- [Upstream cctools-port](https://github.com/tpoechtrager/cctools-port)
- Original PR (merged, release failed): #19
- Failed release graph: [cdd82cd5](https://package-build.anaconda.com/v1/graph/cdd82cd5-8ec6-4564-9b0b-94f3c60c3ec3)

### Explanation of changes:

- Bundle `libtapi.dylib` inside the `ld64` package at `bin/_lib/libtapi.dylib`
- Rewrite `LC_LOAD_DYLIB` for libtapi from `@rpath/libtapi.dylib` to `@loader_path/_lib/libtapi.dylib` via `install_name_tool -change`
- Re-sign the binary with `codesign --sign -` (install_name_tool invalidates the signature)
- Build number stays at 1 (the previous bn1 artifact in xkong-staging has been removed; no conflict)

### Why

The post-merge release build of #19 failed on osx-arm64 at the cctools `configure` step:

```
configure: error: C compiler cannot create executables

dyld: Library not loaded: @rpath/libtapi.dylib
  Referenced from: /private/var/folders/.../T/conda_pkgs_*/ld64-956.6-haf59c80_1/bin/arm64-apple-darwin20.0.0-ld
  Reason: tried: '.../bin/../lib/libtapi.dylib' (no such file)
```

**Root cause:** The ld64 binary has only one `LC_RPATH` entry: `@loader_path/../lib/`. When conda-build extracts `ld64` and `tapi` (a separate package) into different temporary pkgs cache directories on a different filesystem from `_build_env`, conda falls back to **softlinks** (cross-FS — hardlinks not possible). macOS dyld follows the symlink to the binary's real location in the ld64 cache directory, then resolves `@loader_path/../lib/libtapi.dylib` from there — but `lib/` only exists in the `tapi` cache directory, not the `ld64` one, so libtapi is not found.

The binary itself is not broken — it works fine in normal `conda install` environments (verified locally with `conda create -n test ld64=956.6 tapi`, which runs and reports LTO 22.1.2 + TAPI support). The failure is specific to conda-build's `_build_env` when softlinks are used to extract packages from non-pkgs/main channels.

The OLD `ld64-955.13` from pkgs/main has the exact same load commands and would fail in the same scenario, but it happens to always be cached in `~/.conda/pkgs/` (same FS as `_build_env`) so hardlinks work.

### Approaches investigated

| # | Approach | Result |
|---|----------|--------|
| 1 | `install_name_tool -add_rpath "${PREFIX}/lib"` | ❌ conda-build's binary relocation rewrites absolute LC_RPATH back to `@loader_path/../lib/` for portability |
| 2 | `install_name_tool -change @rpath/libtapi.dylib "${PREFIX}/lib/libtapi.dylib"` | ❌ conda-build also rewrites absolute LC_LOAD_DYLIB paths back to `@rpath/...` |
| 3 | Use `@executable_path/../lib` instead of `@loader_path/../lib` | ❌ Verified locally that macOS dyld follows symlinks for BOTH `@executable_path` and `@loader_path` |
| 4 | **Bundle libtapi.dylib inside the ld64 package** | ✅ Works |

### Why approach #4 works

By copying `libtapi.dylib` into `ld64`'s own `bin/_lib/` directory, both files end up in the **same conda package** and therefore the **same cache extraction directory**. Even when dyld follows the softlink to the cache, `@loader_path/_lib/libtapi.dylib` resolves to a path that exists right next to the binary. conda-build's binary relocation leaves `@loader_path/_lib/...` alone because it's already in relocatable form (no absolute prefix to rewrite).

**Trade-off:** ~150 KB of duplication (libtapi copied into the ld64 package). Acceptable.

### Test plan

- [x] Verified OLD and NEW ld64 binaries have identical load commands (not a regression)
- [x] Reproduced failure locally by running the binary from an extracted package location
- [x] Verified fix locally before pushing: extracted broken binary, applied install_name_tool + bundled libtapi, ran via softlink invocation path → succeeds
- [x] CI build passes: [graph 76fb355c](https://package-build.anaconda.com/v1/graph/76fb355c-259b-4f20-a1ec-1d89b98dc58e)
- [x] Verified the packaged binary has `@loader_path/_lib/libtapi.dylib` (not rewritten by conda-build) and `bin/_lib/libtapi.dylib` is present in the package
- [x] Verified the packaged binary runs standalone from any extracted location (no env activation needed)


[PKG-13333]: https://anaconda.atlassian.net/browse/PKG-13333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ